### PR TITLE
Implement AT Protocol OAuth flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,12 +100,12 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atproto-client"
-version = "0.10.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71db40278a96426986f73eaeb9ef3ab67139cad874af47c6b6ceec763aaf710a"
+checksum = "c34ed7ebeec01cd7775c1c7841838c142d123d403983ed7179b31850435b5c7c"
 dependencies = [
  "anyhow",
- "atproto-identity 0.10.0",
+ "atproto-identity",
  "atproto-oauth",
  "atproto-record",
  "bytes",
@@ -122,26 +122,9 @@ dependencies = [
 
 [[package]]
 name = "atproto-identity"
-version = "0.1.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a19e3160f0ccc6f202c75de3395c417facde3a2e7809a69deac2a6738437f2"
-dependencies = [
- "anyhow",
- "futures-util",
- "hickory-resolver",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror 2.0.17",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "atproto-identity"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b4aef048ae058803f44ee184a825063f68c442a34aa719c893cf3e676cdd41"
+checksum = "b956c07726fce812630be63c5cb31b1961cbb70f0a05614278523102d78c3a48"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -161,17 +144,18 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tracing",
+ "urlencoding",
 ]
 
 [[package]]
 name = "atproto-oauth"
-version = "0.10.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60163425b597e4a6d45c26331ff65099cb5c1793ef7ddb41e60e955ceac58f89"
+checksum = "3ea205901c33d074a1b498591d0511bcd788b6772ec0ca6e09a92c4327ddbdff"
 dependencies = [
  "anyhow",
  "async-trait",
- "atproto-identity 0.10.0",
+ "atproto-identity",
  "base64 0.22.1",
  "chrono",
  "ecdsa",
@@ -197,16 +181,16 @@ dependencies = [
 
 [[package]]
 name = "atproto-oauth-axum"
-version = "0.10.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f4d2d994b8aaa0f50f1b90e14725fae1bbe17a12862bc1fb152a3d278a0384"
+checksum = "a3bdfd817dbfd549f63ae6ae39d98a8bc3f193d1b44de64693ebb826caf415fe"
 dependencies = [
  "anyhow",
  "async-trait",
- "atproto-identity 0.10.0",
+ "atproto-identity",
  "atproto-oauth",
  "atproto-record",
- "axum 0.8.7",
+ "axum",
  "chrono",
  "elliptic-curve",
  "hickory-resolver",
@@ -220,42 +204,36 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tracing",
- "urlencoding",
 ]
 
 [[package]]
 name = "atproto-record"
-version = "0.10.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0978d7b7cf50f3316937038d802d5a6141632f4d98c98ed8e0abe22cba91f952"
+checksum = "0550f74423ca745132dc07ba1cb01f2f08243a7bf7497f5c3f2185a774c92ca2"
 dependencies = [
  "anyhow",
- "atproto-identity 0.10.0",
+ "atproto-identity",
+ "base64 0.22.1",
  "chrono",
- "ecdsa",
- "k256",
- "multibase",
- "p256",
  "serde",
  "serde_ipld_dagcbor",
  "serde_json",
  "thiserror 2.0.17",
- "tokio",
- "tracing",
 ]
 
 [[package]]
 name = "atproto-xrpcs"
-version = "0.10.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1183ccecfb2181995b8072d37d4c69fdb59d4b4dbbb3ddd8d556b4d5cf27e5dd"
+checksum = "d2bd3c09bc3e7bbc04fd7271d25184c607644adc4c365633468184edb94094ac"
 dependencies = [
  "anyhow",
  "async-trait",
- "atproto-identity 0.10.0",
+ "atproto-identity",
  "atproto-oauth",
  "atproto-record",
- "axum 0.8.7",
+ "axum",
  "base64 0.22.1",
  "chrono",
  "elliptic-curve",
@@ -270,7 +248,6 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tracing",
- "urlencoding",
 ]
 
 [[package]]
@@ -281,45 +258,11 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b098575ebe77cb6d14fc7f32749631a6e44edbef6b796f89b020e99ba20d425"
 dependencies = [
- "axum-core 0.5.5",
+ "axum-core",
  "axum-macros",
  "bytes",
  "form_urlencoded",
@@ -330,7 +273,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -342,27 +285,6 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -603,6 +525,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +686,16 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+dependencies = [
+ "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -967,6 +910,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -1655,6 +1612,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
+ "serde",
 ]
 
 [[package]]
@@ -1697,12 +1655,6 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
-
-[[package]]
-name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"
@@ -1851,6 +1803,12 @@ dependencies = [
  "smallvec",
  "zeroize",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -2120,6 +2078,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2283,15 +2247,17 @@ dependencies = [
  "anyhow",
  "async-trait",
  "atproto-client",
- "atproto-identity 0.1.1",
+ "atproto-identity",
  "atproto-oauth",
  "atproto-oauth-axum",
  "atproto-record",
  "atproto-xrpcs",
- "axum 0.7.9",
+ "axum",
+ "base64 0.22.1",
  "chrono",
  "config",
  "dotenvy",
+ "rand 0.9.2",
  "regex",
  "reqwest",
  "serde",
@@ -2302,6 +2268,7 @@ dependencies = [
  "tokio-test",
  "tower",
  "tower-http",
+ "tower-sessions",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -3194,6 +3161,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3370,6 +3368,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-cookies"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "151b5a3e3c45df17466454bb74e9ecedecc955269bdedbf4d150dfa393b55a36"
+dependencies = [
+ "axum-core",
+ "cookie",
+ "futures-util",
+ "http",
+ "parking_lot",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-http"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3399,6 +3413,57 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tower-sessions"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a05911f23e8fae446005fe9b7b97e66d95b6db589dc1c4d59f6a2d4d4927d3"
+dependencies = [
+ "async-trait",
+ "http",
+ "time",
+ "tokio",
+ "tower-cookies",
+ "tower-layer",
+ "tower-service",
+ "tower-sessions-core",
+ "tower-sessions-memory-store",
+ "tracing",
+]
+
+[[package]]
+name = "tower-sessions-core"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8cce604865576b7751b7a6bc3058f754569a60d689328bb74c52b1d87e355b"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "base64 0.22.1",
+ "futures",
+ "http",
+ "parking_lot",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "time",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "tower-sessions-memory-store"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb05909f2e1420135a831dd5df9f5596d69196d0a64c3499ca474c4bd3d33242"
+dependencies = [
+ "async-trait",
+ "time",
+ "tokio",
+ "tower-sessions-core",
+]
 
 [[package]]
 name = "tracing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,20 +7,21 @@ license = "MIT"
 
 [dependencies]
 # AT Protocol (Nick Gerakines' crates)
-atproto-client = "0.10"
-atproto-oauth = "0.10"
-atproto-oauth-axum = "0.10"
-atproto-identity = "0.1"
-atproto-record = "0.10"
-atproto-xrpcs = "0.10"
+atproto-client = "0.13"
+atproto-oauth = "0.13"
+atproto-oauth-axum = "0.13"
+atproto-identity = "0.13"
+atproto-record = "0.13"
+atproto-xrpcs = "0.13"
 
 # Async Runtime
 tokio = { version = "1", features = ["full"] }
 
 # Web Framework
-axum = "0.7"
+axum = "0.8"
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace"] }
+tower-sessions = { version = "0.14", features = ["memory-store"] }
 
 # HTTP Client
 reqwest = { version = "0.12", features = ["json"] }
@@ -48,6 +49,8 @@ dotenvy = "0.15"
 async-trait = "0.1"
 
 # Utilities
+base64 = "0.22"
+rand = "0.9"
 url = "2"
 urlencoding = "2"
 regex = "1"

--- a/src/bluesky/oauth.rs
+++ b/src/bluesky/oauth.rs
@@ -1,3 +1,357 @@
-//! OAuth flow helpers
+//! OAuth flow helpers for AT Protocol
+//!
+//! Implements the AT Protocol OAuth flow with PKCE and DPoP.
 
-// TODO: Implement OAuth flow using atproto-oauth-axum
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use reqwest::Client;
+use thiserror::Error;
+use tokio::sync::RwLock;
+
+use atproto_identity::key::{generate_key, KeyData, KeyType};
+use atproto_identity::resolve::SharedIdentityResolver;
+use atproto_oauth::resources::{pds_resources, AuthorizationServer};
+use atproto_oauth::workflow::{
+    oauth_complete, oauth_init, oauth_refresh, OAuthClient, OAuthRequest, OAuthRequestState,
+    ParResponse, TokenResponse,
+};
+
+/// Errors that can occur during OAuth operations
+#[derive(Debug, Error)]
+pub enum OAuthError {
+    #[error("Invalid handle: {0}")]
+    InvalidHandle(String),
+
+    #[error("Failed to resolve identity: {0}")]
+    IdentityResolution(String),
+
+    #[error("Failed to discover authorization server: {0}")]
+    ServerDiscovery(String),
+
+    #[error("OAuth initialization failed: {0}")]
+    InitFailed(String),
+
+    #[error("OAuth completion failed: {0}")]
+    CompleteFailed(String),
+
+    #[error("Token refresh failed: {0}")]
+    RefreshFailed(String),
+
+    #[error("Invalid state parameter")]
+    InvalidState,
+
+    #[error("State expired")]
+    StateExpired,
+
+    #[error("Missing authorization code")]
+    MissingCode,
+
+    #[error("HTTP client error: {0}")]
+    HttpClient(#[from] reqwest::Error),
+
+    #[error("Key generation failed: {0}")]
+    KeyGeneration(String),
+
+    #[error("Key serialization failed: {0}")]
+    KeySerialization(String),
+}
+
+/// Pending OAuth request stored between login and callback
+#[derive(Debug, Clone)]
+pub struct PendingOAuthRequest {
+    pub oauth_request: OAuthRequest,
+    pub authorization_server: AuthorizationServer,
+    pub created_at: DateTime<Utc>,
+}
+
+/// In-memory store for pending OAuth requests
+/// Maps state parameter -> PendingOAuthRequest
+#[derive(Debug, Default)]
+pub struct OAuthStateStore {
+    pending: RwLock<HashMap<String, PendingOAuthRequest>>,
+}
+
+impl OAuthStateStore {
+    pub fn new() -> Self {
+        Self {
+            pending: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Store a pending OAuth request
+    pub async fn store(&self, state: String, request: PendingOAuthRequest) {
+        let mut pending = self.pending.write().await;
+        pending.insert(state, request);
+    }
+
+    /// Retrieve and remove a pending OAuth request
+    pub async fn take(&self, state: &str) -> Option<PendingOAuthRequest> {
+        let mut pending = self.pending.write().await;
+        pending.remove(state)
+    }
+
+    /// Clean up expired requests (older than 10 minutes)
+    pub async fn cleanup_expired(&self) {
+        let mut pending = self.pending.write().await;
+        let cutoff = Utc::now() - chrono::Duration::minutes(10);
+        pending.retain(|_, req| req.created_at > cutoff);
+    }
+}
+
+/// OAuth service for handling AT Protocol authentication
+pub struct OAuthService {
+    http_client: Client,
+    oauth_client: OAuthClient,
+    identity_resolver: SharedIdentityResolver,
+    state_store: Arc<OAuthStateStore>,
+}
+
+impl OAuthService {
+    /// Create a new OAuth service
+    pub fn new(
+        http_client: Client,
+        oauth_client: OAuthClient,
+        identity_resolver: SharedIdentityResolver,
+        state_store: Arc<OAuthStateStore>,
+    ) -> Self {
+        Self {
+            http_client,
+            oauth_client,
+            identity_resolver,
+            state_store,
+        }
+    }
+
+    /// Initiate the OAuth flow for a user handle
+    ///
+    /// Returns the authorization URL to redirect the user to
+    pub async fn initiate_login(&self, handle: &str) -> Result<String, OAuthError> {
+        // 1. Resolve handle to DID and get PDS
+        let document = self
+            .identity_resolver
+            .resolve(handle)
+            .await
+            .map_err(|e| OAuthError::IdentityResolution(e.to_string()))?;
+
+        // Get PDS endpoint from document
+        let pds = document.pds_endpoints().first().cloned().ok_or_else(|| {
+            OAuthError::IdentityResolution("No PDS endpoint in DID document".into())
+        })?;
+
+        // 2. Discover authorization server from PDS
+        let (_protected_resource, authorization_server) = pds_resources(&self.http_client, pds)
+            .await
+            .map_err(|e| OAuthError::ServerDiscovery(e.to_string()))?;
+
+        // 3. Generate PKCE verifier and challenge
+        let (code_verifier, code_challenge) = atproto_oauth::pkce::generate();
+
+        // 4. Generate random state and nonce
+        let state = generate_random_string(32);
+        let nonce = generate_random_string(32);
+
+        // 5. Create OAuth request state
+        let oauth_request_state = OAuthRequestState {
+            state: state.clone(),
+            nonce: nonce.clone(),
+            code_challenge: code_challenge.clone(),
+            scope: "atproto transition:generic".to_string(),
+        };
+
+        // 6. Generate DPoP key
+        let dpop_key_data = generate_dpop_key()?;
+
+        // 7. Call oauth_init to get PAR response
+        let par_response = oauth_init(
+            &self.http_client,
+            &self.oauth_client,
+            &dpop_key_data,
+            Some(handle),
+            &authorization_server,
+            &oauth_request_state,
+        )
+        .await
+        .map_err(|e| OAuthError::InitFailed(e.to_string()))?;
+
+        // 8. Create OAuthRequest for storage
+        let oauth_request = OAuthRequest {
+            oauth_state: state.clone(),
+            issuer: authorization_server.issuer.clone(),
+            authorization_server: authorization_server.issuer.clone(),
+            nonce,
+            pkce_verifier: code_verifier,
+            signing_public_key: serialize_key(&self.oauth_client.private_signing_key_data),
+            dpop_private_key: serialize_key(&dpop_key_data),
+            created_at: Utc::now(),
+            expires_at: Utc::now() + chrono::Duration::seconds(par_response.expires_in as i64),
+        };
+
+        // 9. Store pending request
+        let pending = PendingOAuthRequest {
+            oauth_request,
+            authorization_server: authorization_server.clone(),
+            created_at: Utc::now(),
+        };
+        self.state_store.store(state.clone(), pending).await;
+
+        // 10. Build authorization URL
+        let auth_url = format!(
+            "{}?request_uri={}&client_id={}",
+            authorization_server.authorization_endpoint,
+            urlencoding::encode(&par_response.request_uri),
+            urlencoding::encode(&self.oauth_client.client_id),
+        );
+
+        Ok(auth_url)
+    }
+
+    /// Complete the OAuth flow with the callback code
+    pub async fn complete_login(
+        &self,
+        state: &str,
+        code: &str,
+    ) -> Result<TokenResponse, OAuthError> {
+        // 1. Retrieve pending request
+        let pending = self
+            .state_store
+            .take(state)
+            .await
+            .ok_or(OAuthError::InvalidState)?;
+
+        // 2. Check if expired
+        if pending.oauth_request.expires_at < Utc::now() {
+            return Err(OAuthError::StateExpired);
+        }
+
+        // 3. Deserialize DPoP key
+        let dpop_key_data = deserialize_key(&pending.oauth_request.dpop_private_key)?;
+
+        // 4. Exchange code for tokens
+        let token_response = oauth_complete(
+            &self.http_client,
+            &self.oauth_client,
+            &dpop_key_data,
+            code,
+            &pending.oauth_request,
+            &pending.authorization_server,
+        )
+        .await
+        .map_err(|e| OAuthError::CompleteFailed(e.to_string()))?;
+
+        Ok(token_response)
+    }
+
+    /// Refresh an access token
+    pub async fn refresh_token(
+        &self,
+        refresh_token: &str,
+        did: &str,
+    ) -> Result<TokenResponse, OAuthError> {
+        // Resolve DID to get document for PDS endpoint
+        let document = self
+            .identity_resolver
+            .resolve(did)
+            .await
+            .map_err(|e| OAuthError::IdentityResolution(e.to_string()))?;
+
+        // Generate new DPoP key for refresh
+        let dpop_key_data = generate_dpop_key()?;
+
+        // Refresh tokens
+        let token_response = oauth_refresh(
+            &self.http_client,
+            &self.oauth_client,
+            &dpop_key_data,
+            refresh_token,
+            &document,
+        )
+        .await
+        .map_err(|e| OAuthError::RefreshFailed(e.to_string()))?;
+
+        Ok(token_response)
+    }
+}
+
+/// Generate a cryptographically secure random string
+fn generate_random_string(len: usize) -> String {
+    use rand::Rng;
+    const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    let mut rng = rand::rng();
+    (0..len)
+        .map(|_| {
+            let idx = rng.random_range(0..CHARSET.len());
+            CHARSET[idx] as char
+        })
+        .collect()
+}
+
+/// Generate a DPoP key pair (P-256/ES256)
+fn generate_dpop_key() -> Result<KeyData, OAuthError> {
+    // Generate a P-256 private key for DPoP proofs
+    generate_key(KeyType::P256Private).map_err(|e| OAuthError::KeyGeneration(e.to_string()))
+}
+
+/// Serialize a key for storage
+fn serialize_key(key: &KeyData) -> String {
+    use base64::prelude::*;
+    let (key_type, bytes) = (key.key_type(), key.bytes());
+    let type_byte = match key_type {
+        KeyType::P256Private => 0u8,
+        KeyType::P256Public => 1u8,
+        KeyType::P384Private => 2u8,
+        KeyType::P384Public => 3u8,
+        KeyType::K256Private => 4u8,
+        KeyType::K256Public => 5u8,
+    };
+    let mut data = vec![type_byte];
+    data.extend_from_slice(bytes);
+    BASE64_STANDARD.encode(&data)
+}
+
+/// Deserialize a key from storage
+fn deserialize_key(serialized: &str) -> Result<KeyData, OAuthError> {
+    use base64::prelude::*;
+    let data = BASE64_STANDARD
+        .decode(serialized)
+        .map_err(|e| OAuthError::KeySerialization(e.to_string()))?;
+
+    if data.is_empty() {
+        return Err(OAuthError::KeySerialization("Empty key data".into()));
+    }
+
+    let key_type = match data[0] {
+        0 => KeyType::P256Private,
+        1 => KeyType::P256Public,
+        2 => KeyType::P384Private,
+        3 => KeyType::P384Public,
+        4 => KeyType::K256Private,
+        5 => KeyType::K256Public,
+        _ => return Err(OAuthError::KeySerialization("Unknown key type".into())),
+    };
+
+    Ok(KeyData::new(key_type, data[1..].to_vec()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_random_string() {
+        let s1 = generate_random_string(32);
+        let s2 = generate_random_string(32);
+        assert_eq!(s1.len(), 32);
+        assert_eq!(s2.len(), 32);
+        assert_ne!(s1, s2); // Should be unique
+    }
+
+    #[tokio::test]
+    async fn test_state_store() {
+        let store = OAuthStateStore::new();
+
+        // Test that we can't retrieve a non-existent state
+        assert!(store.take("nonexistent").await.is_none());
+    }
+}

--- a/src/web/handlers/auth.rs
+++ b/src/web/handlers/auth.rs
@@ -5,8 +5,10 @@ use std::sync::Arc;
 use axum::{
     extract::{Query, State},
     response::{Html, IntoResponse, Redirect, Response},
+    Form,
 };
 use serde::Deserialize;
+use tower_sessions::Session;
 
 use crate::AppState;
 
@@ -17,81 +19,220 @@ pub struct CallbackParams {
     pub state: Option<String>,
     pub error: Option<String>,
     pub error_description: Option<String>,
+    pub iss: Option<String>,
 }
 
-/// Initiate OAuth login flow
-pub async fn login(State(_state): State<Arc<AppState>>) -> Response {
-    // TODO: Generate PKCE verifier and state
-    // TODO: Build authorization URL using atproto-oauth
-    // TODO: Store state in session
-    // TODO: Redirect to Bluesky authorization endpoint
+/// Form data for login
+#[derive(Debug, Deserialize)]
+pub struct LoginForm {
+    pub handle: String,
+}
 
-    // For now, return a placeholder
+/// Session keys
+const SESSION_USER_DID: &str = "user_did";
+const SESSION_ACCESS_TOKEN: &str = "access_token";
+const SESSION_REFRESH_TOKEN: &str = "refresh_token";
+
+/// Show login form (GET /auth/login)
+pub async fn login(State(_state): State<Arc<AppState>>) -> Response {
     Html(
         r#"<!DOCTYPE html>
 <html>
-<head><title>Login</title></head>
+<head>
+    <title>Login - Readwise Autosave</title>
+    <style>
+        body { font-family: system-ui, sans-serif; max-width: 400px; margin: 2rem auto; padding: 1rem; }
+        h1 { color: #1185fe; }
+        form { margin-top: 1rem; }
+        label { display: block; margin-bottom: 0.5rem; font-weight: 500; }
+        input[type="text"] {
+            width: 100%; padding: 0.75rem; font-size: 1rem;
+            border: 1px solid #ccc; border-radius: 6px; box-sizing: border-box;
+        }
+        input[type="text"]:focus { outline: 2px solid #1185fe; border-color: #1185fe; }
+        .btn {
+            display: block; width: 100%; background: #1185fe; color: white;
+            padding: 0.75rem 1.5rem; font-size: 1rem; border: none;
+            border-radius: 6px; margin-top: 1rem; cursor: pointer;
+        }
+        .btn:hover { background: #0066cc; }
+        .help { color: #666; font-size: 0.875rem; margin-top: 0.5rem; }
+        .error { color: #d32f2f; background: #ffebee; padding: 0.75rem; border-radius: 6px; margin-bottom: 1rem; }
+    </style>
+</head>
 <body>
-<h1>OAuth Login</h1>
-<p>OAuth flow not yet implemented. Coming soon!</p>
-<p><a href="/">Back to home</a></p>
+    <h1>🦋 Login with Bluesky</h1>
+    <form method="POST" action="/auth/login">
+        <label for="handle">Your Bluesky Handle</label>
+        <input type="text" id="handle" name="handle" placeholder="username.bsky.social" required>
+        <p class="help">Enter your full handle (e.g., alice.bsky.social)</p>
+        <button type="submit" class="btn">Continue with Bluesky</button>
+    </form>
+    <p><a href="/">← Back to home</a></p>
 </body>
 </html>"#,
     )
     .into_response()
 }
 
-/// Handle OAuth callback
+/// Handle login form submission (POST /auth/login)
+pub async fn login_submit(
+    State(state): State<Arc<AppState>>,
+    Form(form): Form<LoginForm>,
+) -> Response {
+    let handle = form.handle.trim();
+
+    // Validate handle format
+    if handle.is_empty() {
+        return show_login_error("Please enter your Bluesky handle").into_response();
+    }
+
+    // Initiate OAuth flow
+    match state.oauth_service.initiate_login(handle).await {
+        Ok(auth_url) => {
+            tracing::info!("Redirecting user to authorization URL");
+            Redirect::to(&auth_url).into_response()
+        }
+        Err(e) => {
+            tracing::error!("OAuth initiation failed: {}", e);
+            show_login_error(&format!("Failed to start login: {}", e)).into_response()
+        }
+    }
+}
+
+/// Handle OAuth callback (GET /auth/callback)
 pub async fn callback(
-    State(_state): State<Arc<AppState>>,
+    State(state): State<Arc<AppState>>,
+    session: Session,
     Query(params): Query<CallbackParams>,
 ) -> Response {
     // Check for errors from the OAuth provider
     if let Some(error) = params.error {
         let description = params.error_description.unwrap_or_default();
-        return Html(format!(
-            r#"<!DOCTYPE html>
-<html>
-<head><title>Login Error</title></head>
-<body>
-<h1>Login Failed</h1>
-<p>Error: {} - {}</p>
-<p><a href="/">Try again</a></p>
-</body>
-</html>"#,
-            error, description
-        ))
-        .into_response();
+        tracing::error!("OAuth error: {} - {}", error, description);
+        return show_callback_error(&error, &description).into_response();
     }
 
-    // TODO: Verify state parameter
-    // TODO: Exchange code for tokens using PKCE
-    // TODO: Get user info (DID, handle)
-    // TODO: Create or update user in database
-    // TODO: Create session
-    // TODO: Redirect to dashboard
+    // Get required parameters
+    let code = match params.code {
+        Some(c) => c,
+        None => {
+            return show_callback_error("Missing Code", "No authorization code received")
+                .into_response()
+        }
+    };
 
-    if let Some(_code) = params.code {
-        // Placeholder success response
-        Redirect::to("/dashboard").into_response()
-    } else {
-        Html(
-            r#"<!DOCTYPE html>
-<html>
-<head><title>Error</title></head>
-<body>
-<h1>Missing Authorization Code</h1>
-<p><a href="/">Try again</a></p>
-</body>
-</html>"#,
-        )
-        .into_response()
+    let oauth_state = match params.state {
+        Some(s) => s,
+        None => {
+            return show_callback_error("Missing State", "No state parameter received")
+                .into_response()
+        }
+    };
+
+    // Complete the OAuth flow
+    match state
+        .oauth_service
+        .complete_login(&oauth_state, &code)
+        .await
+    {
+        Ok(token_response) => {
+            // Get user DID from token response
+            let user_did = token_response.sub.unwrap_or_default();
+
+            if user_did.is_empty() {
+                return show_callback_error("Invalid Response", "No user DID in token response")
+                    .into_response();
+            }
+
+            // Store tokens in session
+            if let Err(e) = session.insert(SESSION_USER_DID, &user_did).await {
+                tracing::error!("Failed to store user DID in session: {}", e);
+            }
+            if let Err(e) = session
+                .insert(SESSION_ACCESS_TOKEN, &token_response.access_token)
+                .await
+            {
+                tracing::error!("Failed to store access token in session: {}", e);
+            }
+            if let Some(ref refresh_token) = token_response.refresh_token {
+                if let Err(e) = session.insert(SESSION_REFRESH_TOKEN, refresh_token).await {
+                    tracing::error!("Failed to store refresh token in session: {}", e);
+                }
+            }
+
+            tracing::info!("User {} logged in successfully", user_did);
+
+            // Redirect to dashboard
+            Redirect::to("/dashboard").into_response()
+        }
+        Err(e) => {
+            tracing::error!("OAuth completion failed: {}", e);
+            show_callback_error("Login Failed", &e.to_string()).into_response()
+        }
     }
 }
 
-/// Handle logout
-pub async fn logout(State(_state): State<Arc<AppState>>) -> Redirect {
-    // TODO: Clear session
-    // TODO: Revoke tokens if needed
+/// Handle logout (POST /auth/logout)
+pub async fn logout(session: Session) -> Redirect {
+    // Clear session
+    if let Err(e) = session.delete().await {
+        tracing::error!("Failed to delete session: {}", e);
+    }
     Redirect::to("/")
+}
+
+/// Show login error page
+fn show_login_error(message: &str) -> Html<String> {
+    Html(format!(
+        r#"<!DOCTYPE html>
+<html>
+<head>
+    <title>Login Error - Readwise Autosave</title>
+    <style>
+        body {{ font-family: system-ui, sans-serif; max-width: 400px; margin: 2rem auto; padding: 1rem; }}
+        h1 {{ color: #d32f2f; }}
+        .error {{ color: #d32f2f; background: #ffebee; padding: 0.75rem; border-radius: 6px; }}
+        .btn {{ display: inline-block; background: #1185fe; color: white; padding: 0.75rem 1.5rem;
+                text-decoration: none; border-radius: 6px; margin-top: 1rem; }}
+    </style>
+</head>
+<body>
+    <h1>Login Error</h1>
+    <div class="error">{}</div>
+    <a href="/auth/login" class="btn">Try Again</a>
+</body>
+</html>"#,
+        message
+    ))
+}
+
+/// Show callback error page
+fn show_callback_error(error: &str, description: &str) -> Html<String> {
+    Html(format!(
+        r#"<!DOCTYPE html>
+<html>
+<head>
+    <title>Login Failed - Readwise Autosave</title>
+    <style>
+        body {{ font-family: system-ui, sans-serif; max-width: 400px; margin: 2rem auto; padding: 1rem; }}
+        h1 {{ color: #d32f2f; }}
+        .error {{ background: #ffebee; padding: 1rem; border-radius: 6px; margin: 1rem 0; }}
+        .error-title {{ color: #d32f2f; font-weight: bold; margin: 0 0 0.5rem 0; }}
+        .error-desc {{ color: #666; margin: 0; }}
+        .btn {{ display: inline-block; background: #1185fe; color: white; padding: 0.75rem 1.5rem;
+                text-decoration: none; border-radius: 6px; }}
+    </style>
+</head>
+<body>
+    <h1>Login Failed</h1>
+    <div class="error">
+        <p class="error-title">{}</p>
+        <p class="error-desc">{}</p>
+    </div>
+    <a href="/auth/login" class="btn">Try Again</a>
+</body>
+</html>"#,
+        error, description
+    ))
 }

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -17,7 +17,10 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .route("/", get(handlers::index))
         .route("/health", get(handlers::health))
         // Auth routes
-        .route("/auth/login", get(handlers::auth::login))
+        .route(
+            "/auth/login",
+            get(handlers::auth::login).post(handlers::auth::login_submit),
+        )
         .route("/auth/callback", get(handlers::auth::callback))
         .route("/auth/logout", post(handlers::auth::logout))
         // Dashboard routes


### PR DESCRIPTION
## Summary

- Implement full AT Protocol OAuth flow with PKCE and DPoP support
- Add login form UI for entering Bluesky handle
- Complete OAuth callback handling with token storage in sessions
- Update all atproto-* crates to v0.13 for latest OAuth API

## Changes

### Dependencies
- Update atproto-* crates from 0.10 to 0.13
- Update axum from 0.7 to 0.8 (required by atproto-oauth-axum)
- Add tower-sessions for session management
- Add base64 and rand for key serialization and state generation

### OAuth Implementation (`src/bluesky/oauth.rs`)
- `OAuthService`: Main service handling login initiation, callback completion, and token refresh
- `OAuthStateStore`: In-memory store for pending OAuth requests between login and callback
- Key generation and serialization functions for DPoP keys

### Auth Handlers (`src/web/handlers/auth.rs`)
- Login form UI with handle input
- `login_submit` handler for initiating OAuth PAR flow
- Updated `callback` handler for token exchange and session creation
- Error pages for OAuth failures

### Application State (`src/main.rs`)
- Add `OAuthService` to `AppState`
- Initialize identity resolver with DNS and HTTP resolution
- Generate signing key for OAuth client assertions
- Add session middleware layer

## Test Plan

- [x] All 18 existing tests pass
- [x] Clippy passes with no warnings
- [x] Code is formatted correctly
- [ ] Manual test: Start server and navigate to `/auth/login`
- [ ] Manual test: Enter a Bluesky handle and verify redirect to authorization server
- [ ] Integration test with actual Bluesky OAuth (requires valid client metadata URL)

## Notes

- The OAuth client_id and redirect_uri are configurable via `OAUTH_CLIENT_ID` and `OAUTH_REDIRECT_URI` environment variables
- For production use, the signing key should be persisted instead of generated on each startup
- Token refresh is implemented but not yet integrated into the background services

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)